### PR TITLE
[codex] Fix axios security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "antd": "3.9.2",
-    "axios": "^0.18.0",
+    "axios": "^1.18.0",
     "file-loader": "^1.1.11",
     "history": "^4.7.2",
     "prop-types": "^15.6.2",


### PR DESCRIPTION
## What changed
- Updated `axios` from `^0.18.0` to `^1.18.0`.

## Why
GitHub Dependabot reported multiple security advisories against the direct `axios` dependency in `package.json`.

## Validation
- `npm install --ignore-scripts --no-package-lock --legacy-peer-deps`
- `npm list axios` resolves `axios@1.18.0`
- `NODE_OPTIONS="--openssl-legacy-provider --localstorage-file=.node-localstorage" npx webpack -p --progress`

Note: this repo does not commit a lockfile, so `npm audit` cannot run without generating one.